### PR TITLE
Handle overbooked specified dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,8 +241,7 @@
           const date = dv.querySelector('[type="date"]').value;
           const hrs = Number(dv.querySelector('[type="number"]').value) || 0;
           if (date && sched[date]) {
-            const avail = 8 - sched[date].tot;
-            const add = Math.min(avail, hrs);
+            const add = hrs;
             if (add > 0) {
               sched[date].assign[code] = (sched[date].assign[code] || 0) + add;
               sched[date].tot += add;
@@ -283,6 +282,12 @@
             }
           });
         });
+      });
+
+      Object.keys(sched).forEach(dtKey => {
+        if (sched[dtKey].tot > 8) {
+          warns.push(`${dtKey} 指定時數達 ${sched[dtKey].tot} 小時`);
+        }
       });
 
       // 4. 補滿每日至 8 小時，並標示剩餘代碼


### PR DESCRIPTION
## Summary
- Add direct accumulation of specified-date hours without limiting to daily availability
- Warn when specified hours exceed 8 for any day and display alerts atop results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a28fea148331920cc2a9d9fede23