### PR TITLE
Exclude weekend columns from schedule output

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,13 +333,18 @@
       let html = '';
       if (warns.length) html += `<div style="color:red;">${warns.join('<br>')}</div>`;
       html += '<div class="table-scroll"><table><thead><tr><th></th>';
-      for (let d = 1; d <= days; d++) html += `<th>${d}</th>`;
+      for (let d = 1; d <= days; d++) {
+        const dow = new Date(year, month - 1, d).getDay();
+        if (dow === 0 || dow === 6) continue;
+        html += `<th>${d}</th>`;
+      }
       html += '</tr><tr><th></th>';
       for (let d = 1; d <= days; d++) {
-        const dow = new Date(year, month-1, d).getDay();
-        let cls = (dow === 0 || dow === 6) ? 'weekend' : '';
+        const dow = new Date(year, month - 1, d).getDay();
+        if (dow === 0 || dow === 6) continue;
+        let cls = '';
         const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
-        if (userHols[key]) cls += ' holiday';
+        if (userHols[key]) cls = 'holiday';
         html += `<th class="${cls}">${['日','一','二','三','四','五','六'][dow]}</th>`;
       }
       html += '</tr></thead><tbody>';
@@ -347,6 +352,8 @@
       codes.forEach(code => {
         html += `<tr><td>${code}</td>`;
         for (let d = 1; d <= days; d++) {
+          const dow = new Date(year, month - 1, d).getDay();
+          if (dow === 0 || dow === 6) continue;
           const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
           html += `<td>${sched[key].assign[code] || ''}</td>`;
         }
@@ -364,14 +371,33 @@
       const days = new Date(Number(year), Number(month), 0).getDate();
       const aoa = [];
       // 日期行
-      const header = ['']; for (let d = 1; d <= days; d++) header.push(`${year}/${month}/${d}`);
+      const header = [''];
+      for (let d = 1; d <= days; d++) {
+        const dow = new Date(Number(year), Number(month) - 1, d).getDay();
+        if (dow === 0 || dow === 6) continue;
+        header.push(`${year}/${month}/${d}`);
+      }
       aoa.push(header);
       // 星期行
-      const wk = ['']; for (let d = 1; d <= days; d++) { const dow = new Date(Number(year), Number(month) - 1, d).getDay(); wk.push(['日','一','二','三','四','五','六'][dow]); }
+      const wk = [''];
+      for (let d = 1; d <= days; d++) {
+        const dow = new Date(Number(year), Number(month) - 1, d).getDay();
+        if (dow === 0 || dow === 6) continue;
+        wk.push(['日','一','二','三','四','五','六'][dow]);
+      }
       aoa.push(wk);
       // 資料行
       const codes = Array.from(new Set([].concat(...Object.values(sched).map(day => Object.keys(day.assign)))));
-      codes.forEach(code => { const row = [code]; for (let d = 1; d <= days; d++) { const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`; row.push(sched[key].assign[code] || ''); } aoa.push(row); });
+      codes.forEach(code => {
+        const row = [code];
+        for (let d = 1; d <= days; d++) {
+          const dow = new Date(Number(year), Number(month) - 1, d).getDay();
+          if (dow === 0 || dow === 6) continue;
+          const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+          row.push(sched[key].assign[code] || '');
+        }
+        aoa.push(row);
+      });
       const ws = XLSX.utils.aoa_to_sheet(aoa);
       const wb = XLSX.utils.book_new(); XLSX.utils.book_append_sheet(wb, ws, `${year}年${month}月`);
       const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });


### PR DESCRIPTION
## Summary
- Skip weekend days when building the schedule table so only weekdays are displayed.
- Exclude weekend dates from the exported Excel worksheet.

## Testing
- `node -e "function getWeekdays(year,month){const days=new Date(year,month,0).getDate();const headers=[];const dowNames=[];for(let d=1;d<=days;d++){const dow=new Date(year,month-1,d).getDay();if(dow===0||dow===6)continue;headers.push(d);dowNames.push(['日','一','二','三','四','五','六'][dow]);}return{headers,dowNames};}console.log(getWeekdays(2024,7));"`
- `node -e "function buildAoa(year, month) { const days = new Date(year, month, 0).getDate(); const sched = {}; for (let d = 1; d <= days; d++) { const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`; sched[key] = { assign: { CODE: d } }; } const aoa = []; const header = ['']; for (let d = 1; d <= days; d++) { const dow = new Date(year, month - 1, d).getDay(); if (dow === 0 || dow === 6) continue; header.push(`${year}/${String(month).padStart(2,'0')}/${d}`); } aoa.push(header); const wk = ['']; for (let d = 1; d <= days; d++) { const dow = new Date(year, month - 1, d).getDay(); if (dow === 0 || dow === 6) continue; wk.push(['日','一','二','三','四','五','六'][dow]); } aoa.push(wk); const codes = ['CODE']; codes.forEach(code => { const row = [code]; for (let d = 1; d <= days; d++) { const dow = new Date(year, month - 1, d).getDay(); if (dow === 0 || dow === 6) continue; const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`; row.push(sched[key].assign[code] || ''); } aoa.push(row); }); return aoa; } console.log(buildAoa(2024,7));"`

------
https://chatgpt.com/codex/tasks/task_e_6895abe20a988331ad7b9f4d53e5af88