### PR TITLE
Exclude projects and columns for holidays

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,26 +347,28 @@
       for (let d = 1; d <= days; d++) {
         const dow = new Date(year, month - 1, d).getDay();
         if (dow === 0 || dow === 6) continue;
+        const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+        if (userHols[key]) continue;
         html += `<th>${d}</th>`;
       }
       html += '</tr><tr><th></th>';
       for (let d = 1; d <= days; d++) {
         const dow = new Date(year, month - 1, d).getDay();
         if (dow === 0 || dow === 6) continue;
-        let cls = '';
         const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
-        if (userHols[key]) cls = 'holiday';
-        html += `<th class="${cls}">${['日','一','二','三','四','五','六'][dow]}</th>`;
+        if (userHols[key]) continue;
+        html += `<th>${['日','一','二','三','四','五','六'][dow]}</th>`;
       }
       html += '</tr></thead><tbody>';
       const codes = Array.from(new Set([].concat(...Object.values(sched).map(day => Object.keys(day.assign)))))
-        .filter(code => Object.values(sched).some(day => day.assign[code] > 0));
+        .filter(code => Object.entries(sched).some(([key, day]) => !userHols[key] && day.assign[code] > 0));
       codes.forEach(code => {
         html += `<tr><td>${code}</td>`;
         for (let d = 1; d <= days; d++) {
           const dow = new Date(year, month - 1, d).getDay();
           if (dow === 0 || dow === 6) continue;
           const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+          if (userHols[key]) continue;
           const val = sched[key].assign[code];
           html += `<td>${val !== undefined ? val : ''}</td>`;
         }


### PR DESCRIPTION
## Summary
- Skip rendering table headers and cells for holiday dates.
- Omit projects that only log hours on holidays so they don't produce empty rows.

## Testing
- `node - <<'NODE'\nconst fs = require('fs'), vm = require('vm');\nconst resultHolder = { innerHTML: '' };\nglobal.document = { getElementById: id => resultHolder };\nglobal.userHols = { '2024-01-01': true };\nconst html = fs.readFileSync('index.html', 'utf8');\nconst match = html.match(/function renderResult[\\s\\S]*?\\n\\s*}\\n\\n\\s*\\/\\/ 匯出Excel/);\nconst funcCode = match[0].replace(/\\n\\s*\\/\\/ 匯出Excel[\\s\\S]*/, '');\nvm.runInThisContext(funcCode);\nconst sched = {\n  '2024-01-01': { assign: { 'HOLCODE': 8, 'A': 2 }, dow: 1, tot: 8 },\n  '2024-01-02': { assign: { 'B': 4 }, dow: 2, tot: 4 }\n};\nrenderResult(sched, [], 2024, 1, 2);\nconsole.log(JSON.stringify(resultHolder.innerHTML));\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_6895b74a9c3c8331957c0b54739505b4