### PR TITLE
Include weekends in schedule and export

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,16 +346,15 @@
       html += '<div class="table-scroll"><table><thead><tr><th></th>';
       for (let d = 1; d <= days; d++) {
         const dow = new Date(year, month - 1, d).getDay();
-        if (dow === 0 || dow === 6) continue;
-        html += `<th>${d}</th>`;
+        const cls = (dow === 0 || dow === 6) ? 'weekend' : '';
+        html += `<th class="${cls}">${d}</th>`;
       }
       html += '</tr><tr><th></th>';
       for (let d = 1; d <= days; d++) {
         const dow = new Date(year, month - 1, d).getDay();
-        if (dow === 0 || dow === 6) continue;
-        let cls = '';
+        let cls = (dow === 0 || dow === 6) ? 'weekend' : '';
         const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
-        if (userHols[key]) cls = 'holiday';
+        if (userHols[key]) cls += (cls ? ' ' : '') + 'holiday';
         html += `<th class="${cls}">${['日','一','二','三','四','五','六'][dow]}</th>`;
       }
       html += '</tr></thead><tbody>';
@@ -365,10 +364,11 @@
         html += `<tr><td>${code}</td>`;
         for (let d = 1; d <= days; d++) {
           const dow = new Date(year, month - 1, d).getDay();
-          if (dow === 0 || dow === 6) continue;
           const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
           const val = sched[key].assign[code];
-          html += `<td>${val !== undefined ? val : ''}</td>`;
+          let cls = (dow === 0 || dow === 6) ? 'weekend' : '';
+          if (userHols[key]) cls += (cls ? ' ' : '') + 'holiday';
+          html += `<td class="${cls}">${val !== undefined ? val : ''}</td>`;
         }
         html += '</tr>';
       });
@@ -386,8 +386,6 @@
       // 日期行
       const header = [''];
       for (let d = 1; d <= days; d++) {
-        const dow = new Date(Number(year), Number(month) - 1, d).getDay();
-        if (dow === 0 || dow === 6) continue;
         header.push(`${year}/${month}/${d}`);
       }
       aoa.push(header);
@@ -395,7 +393,6 @@
       const wk = [''];
       for (let d = 1; d <= days; d++) {
         const dow = new Date(Number(year), Number(month) - 1, d).getDay();
-        if (dow === 0 || dow === 6) continue;
         wk.push(['日','一','二','三','四','五','六'][dow]);
       }
       aoa.push(wk);


### PR DESCRIPTION
## Summary
- Show weekend columns in rendered schedule table and mark them with the existing `weekend` style.
- Export weekends in Excel output so all days of the month are included.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6895b7fa16c0833197b820dcb8b7289c