### PR TITLE
Style weekend and holiday headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,10 @@
     table { width: 100%; border-collapse: collapse; min-width: 600px; }
     th, td { border: 1px solid #ddd; padding: 8px; text-align: center; font-size: .9em; }
     th { background: #4caf50; color: #fff; }
-    .weekend { background: #fcf8e3; }
-    .holiday { background: #fbe9e7; }
+    .weekend, .holiday {
+      background: #ccc;
+      color: #333;
+    }
     .modal {
       display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%;
       background: rgba(0,0,0,0.5); z-index: 1000; align-items: center; justify-content: center;
@@ -346,7 +348,9 @@
       html += '<div class="table-scroll"><table><thead><tr><th></th>';
       for (let d = 1; d <= days; d++) {
         const dow = new Date(year, month - 1, d).getDay();
-        const cls = (dow === 0 || dow === 6) ? 'weekend' : '';
+        let cls = (dow === 0 || dow === 6) ? 'weekend' : '';
+        const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+        if (userHols[key]) cls += (cls ? ' ' : '') + 'holiday';
         html += `<th class="${cls}">${d}</th>`;
       }
       html += '</tr><tr><th></th>';


### PR DESCRIPTION
## Summary
- style weekend and holiday cells with unified gray background and text
- ensure date headers mark weekends and holidays for consistent styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895bd3954348331bad4bf939e99944e