### PR TITLE
Apply holiday styling to calendar headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,9 @@
       html += '<div class="table-scroll"><table><thead><tr><th></th>';
       for (let d = 1; d <= days; d++) {
         const dow = new Date(year, month - 1, d).getDay();
-        const cls = (dow === 0 || dow === 6) ? 'weekend' : '';
+        const key = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+        let cls = (dow === 0 || dow === 6) ? 'weekend' : '';
+        if (userHols[key]) cls += (cls ? ' ' : '') + 'holiday';
         html += `<th class="${cls}">${d}</th>`;
       }
       html += '</tr><tr><th></th>';


### PR DESCRIPTION
## Summary
- add holiday class to top date headers when user-defined holidays match
- ensure both date and weekday headers include weekend and holiday styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895bd3e03c48331b196f789a898b526