### PR TITLE
Update weekend and holiday styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,10 +56,8 @@
     table { width: 100%; border-collapse: collapse; min-width: 600px; }
     th, td { border: 1px solid #ddd; padding: 8px; text-align: center; font-size: .9em; }
     th { background: #4caf50; color: #fff; }
-    .weekend, .holiday {
-      background: #ccc;
-      color: #333;
-    }
+    th.weekend, th.holiday { background: #FFC000; color: #000; }
+    td.weekend, td.holiday { background: #FFF2CC; }
     .modal {
       display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%;
       background: rgba(0,0,0,0.5); z-index: 1000; align-items: center; justify-content: center;


### PR DESCRIPTION
## Summary
- Adjust calendar styles so header weekends/holidays use black text on `#FFC000` and data cells use `#FFF2CC`
- Confirm renderResult applies `weekend` and `holiday` classes to generated `<th>` and `<td>` elements

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c09c9f78833184842d241a8d1344